### PR TITLE
minor fixes, API change and conditional statements for sliding

### DIFF
--- a/Docs/ScrollerBar.md
+++ b/Docs/ScrollerBar.md
@@ -1,6 +1,6 @@
 Class: ScrollerBar {#ScrollerBar}
 ==========================================
-This class provides a simple, fully customizeable interface for creating custom scrollbars both horizontal and vertical.
+This class provides a simple, fully customizable interface for creating custom scrollbars both horizontal and vertical.
 
 ScrollerBar Method: constructor {#ScrollerBar:constructor}
 ---------------------------------
@@ -14,8 +14,8 @@ ScrollerBar Method: constructor {#ScrollerBar:constructor}
 2. options - (Object - optional) See below:
 
 ### Options:
-1. step (`int`) how many pixels to move for each scroll step (default is `30`)
-2. mode (`string`) can be either `vertical` or `horizontal`(default is `vertical`)
+1. step (`int`) how many pixels to move for each scroll step (default is `30`).
+2. mode (`string`) can be either `vertical` or `horizontal` (default is `vertical`).
 3. margins (`int`) how many margins to add to the end of the scroll zone (can help fix some issues). default is `0`.
 4. alwaysShow (`bool`) - if set to true, will show the bar even if there is no scrolling needed. default is `false`.
 5. scrollerHTML (`string`) - the html used to create the ScrollerBar. If you wish to customize it, make sure you keep the default class names, or it will break:
@@ -26,12 +26,12 @@ ScrollerBar Method: constructor {#ScrollerBar:constructor}
         - decrease - the decrease button (down/right)
 6. wrapped (`Element` | `String`) - if provided, the class will use this element for creating the scroller effect instead of creating a wrapping element.
 
-*note: the scroller element will be added with a class representing it's mode (vertical/horizontal) so that you can style it, allowing you to use both types on the same element*
+*note: the scroller element will be added with a class representing its mode (vertical/horizontal) so that you can style it, allowing you to use both types on the same element.*
 
 
 ScrollerBar Method detach : {#ScrollerBar:detach}
 ----------------
-Dettaches the scroller from the element
+Detaches the scroller from the element.
 
 ### Syntax:
     
@@ -42,7 +42,7 @@ Dettaches the scroller from the element
     
 ScrollerBar Method: attach {#ScrollerBar:attach}
 ----------------
-Reattaches the scroller to it's element
+Reattaches the scroller to its element.
 
 ### Syntax:
     
@@ -53,7 +53,7 @@ Reattaches the scroller to it's element
     
 ScrollerBar Method: increase {#ScrollerBar:increase}
 ----------------
-Advances the scroller
+Advances the scroller.
 
 ### Syntax:
     
@@ -61,13 +61,13 @@ Advances the scroller
 
 ### Arguments:
 
-1. pixels (`int` - optional) - how many pixels to increase. If non supplied will use the `steps` option
+1. pixels (`int` - optional) - how many pixels to increase. If not supplied will use the `steps` option.
 
 
 
 ScrollerBar Method: increase {#ScrollerBar:decrease}
 ----------------
-Regresses the scroller
+Regresses the scroller.
 
 ### Syntax:
     
@@ -75,12 +75,12 @@ Regresses the scroller
 
 ### Arguments:
 
-1. pixels (`int` - optional) - how many pixels to increase. If non supplied will use the `steps` option
+1. pixels (`int` - optional) - how many pixels to increase. If not supplied will use the `steps` option.
     
 
     
 ScrollerBar : Events {#ScrollerBar:Events}
 ---------------
- * `increase`  - fired when the is an increase in the scroller. Will pass the number of pixels moved as an argument
- * `decrease` - fired when the is a decrease in the scroller. Will pass the number of pixels moved as an argument
+ * `increase`  - fired when there is an increase in the scroller. Will pass the number of pixels moved as an argument.
+ * `decrease` - fired when there is a decrease in the scroller. Will pass the number of pixels moved as an argument.
  

--- a/Docs/ScrollerBar.md
+++ b/Docs/ScrollerBar.md
@@ -10,21 +10,21 @@ ScrollerBar Method: constructor {#ScrollerBar:constructor}
 
 ### Arguments:
 
-1. wrapper - (string | Element) - The element for which you want to apply the scrolling.
-2. options - (Object - optional) See below:
+1. wrapper - (Element, string) - The element for which you want to apply the scrolling.
+2. options - (Object, optional) See below:
 
 ### Options:
-1. step (`int`) how many pixels to move for each scroll step (default is `30`).
-2. mode (`string`) can be either `vertical` or `horizontal` (default is `vertical`).
-3. margins (`int`) how many margins to add to the end of the scroll zone (can help fix some issues). default is `0`.
-4. alwaysShow (`bool`) - if set to true, will show the bar even if there is no scrolling needed. default is `false`.
-5. scrollerHTML (`string`) - the html used to create the ScrollerBar. If you wish to customize it, make sure you keep the default class names, or it will break:
-        - scroller - the ScrollerBar container
-        - scroll - the scroll area
-        - handle - the scroll handle
-        - increase - the increase button (up/left)
-        - decrease - the decrease button (down/right)
-6. wrapped (`Element` | `String`) - if provided, the class will use this element for creating the scroller effect instead of creating a wrapping element.
+1. `step` (int) how many pixels to move for each scroll step (default is `30`).
+2. `mode` (string) can be either `vertical` or `horizontal` (default is `vertical`).
+3. `margins` (int) how many margins to add to the end of the scroll zone (can help fix some issues). default is `0`.
+4. `alwaysShow` (bool) - if set to true, will show the bar even if there is no scrolling needed. default is `false`.
+5. `crollerHTML` (string) - the html used to create the ScrollerBar. If you wish to customize it, make sure you keep the default class names, or it will break:
+    * `scroller` - the ScrollerBar container
+    * `scroll` - the scroll area
+    * `handle` - the scroll handle
+    * `increase` - the increase button (up/left)
+    * `decrease` - the decrease button (down/right)
+6. `wrapped` (Element, string) - if provided, the class will use this element for creating the scroller effect instead of creating a wrapping element.
 
 *note: the scroller element will be added with a class representing its mode (vertical/horizontal) so that you can style it, allowing you to use both types on the same element.*
 
@@ -61,7 +61,7 @@ Advances the scroller.
 
 ### Arguments:
 
-1. pixels (`int` - optional) - how many pixels to increase. If not supplied will use the `steps` option.
+1. pixels (int, optional) - how many pixels to increase. If not supplied will use the `steps` option.
 
 
 
@@ -75,12 +75,12 @@ Regresses the scroller.
 
 ### Arguments:
 
-1. pixels (`int` - optional) - how many pixels to increase. If not supplied will use the `steps` option.
+1. pixels (int, optional) - how many pixels to increase. If not supplied will use the `steps` option.
     
 
     
 ScrollerBar : Events {#ScrollerBar:Events}
 ------------------------------------------
- * `increase`  - fired when there is an increase in the scroller. Will pass the number of pixels moved as an argument.
- * `decrease` - fired when there is a decrease in the scroller. Will pass the number of pixels moved as an argument.
+* `increase`  - fired when there is an increase in the scroller. Will pass the number of pixels moved as an argument.
+* `decrease` - fired when there is a decrease in the scroller. Will pass the number of pixels moved as an argument.
  

--- a/Docs/ScrollerBar.md
+++ b/Docs/ScrollerBar.md
@@ -65,7 +65,7 @@ Advances the scroller.
 
 
 
-ScrollerBar Method: increase {#ScrollerBar:decrease}
+ScrollerBar Method: decrease {#ScrollerBar:decrease}
 ----------------------------------------------------
 Regresses the scroller.
 

--- a/Docs/ScrollerBar.md
+++ b/Docs/ScrollerBar.md
@@ -1,9 +1,9 @@
 Class: ScrollerBar {#ScrollerBar}
-==========================================
+=================================
 This class provides a simple, fully customizable interface for creating custom scrollbars both horizontal and vertical.
 
 ScrollerBar Method: constructor {#ScrollerBar:constructor}
----------------------------------
+----------------------------------------------------------
 ### Syntax:
 
 	var scroller = new ScrollerBar(wrapper[,options]);
@@ -30,7 +30,7 @@ ScrollerBar Method: constructor {#ScrollerBar:constructor}
 
 
 ScrollerBar Method detach : {#ScrollerBar:detach}
-----------------
+-------------------------------------------------
 Detaches the scroller from the element.
 
 ### Syntax:
@@ -41,7 +41,7 @@ Detaches the scroller from the element.
 
     
 ScrollerBar Method: attach {#ScrollerBar:attach}
-----------------
+------------------------------------------------
 Reattaches the scroller to its element.
 
 ### Syntax:
@@ -52,7 +52,7 @@ Reattaches the scroller to its element.
 
     
 ScrollerBar Method: increase {#ScrollerBar:increase}
-----------------
+----------------------------------------------------
 Advances the scroller.
 
 ### Syntax:
@@ -66,7 +66,7 @@ Advances the scroller.
 
 
 ScrollerBar Method: increase {#ScrollerBar:decrease}
-----------------
+----------------------------------------------------
 Regresses the scroller.
 
 ### Syntax:
@@ -80,7 +80,7 @@ Regresses the scroller.
 
     
 ScrollerBar : Events {#ScrollerBar:Events}
----------------
+------------------------------------------
  * `increase`  - fired when there is an increase in the scroller. Will pass the number of pixels moved as an argument.
  * `decrease` - fired when there is a decrease in the scroller. Will pass the number of pixels moved as an argument.
  

--- a/Docs/ScrollerBar.md
+++ b/Docs/ScrollerBar.md
@@ -16,7 +16,7 @@ ScrollerBar Method: constructor {#ScrollerBar:constructor}
 ### Options:
 1. `step` (int) how many pixels to move for each scroll step (default is `30`).
 2. `mode` (string) can be either `vertical` or `horizontal` (default is `vertical`).
-3. `margins` (int) how many margins to add to the end of the scroll zone (can help fix some issues) (default is `0`).
+3. `margin` (int) how much margin to add to the end of the scroll zone (can help fix some issues) (default is `0`).
 4. `alwaysShow` (bool) - if set to true, will show the bar even if there is no scrolling needed (default is `false`).
 5. `scrollerHTML` (string) - the html used to create the ScrollerBar. If you wish to customize it, make sure you keep the default class names, or it will break:
     * `scroller` - the ScrollerBar container

--- a/Docs/ScrollerBar.md
+++ b/Docs/ScrollerBar.md
@@ -18,7 +18,7 @@ ScrollerBar Method: constructor {#ScrollerBar:constructor}
 2. `mode` (string) can be either `vertical` or `horizontal` (default is `vertical`).
 3. `margins` (int) how many margins to add to the end of the scroll zone (can help fix some issues) (default is `0`).
 4. `alwaysShow` (bool) - if set to true, will show the bar even if there is no scrolling needed (default is `false`).
-5. `crollerHTML` (string) - the html used to create the ScrollerBar. If you wish to customize it, make sure you keep the default class names, or it will break:
+5. `scrollerHTML` (string) - the html used to create the ScrollerBar. If you wish to customize it, make sure you keep the default class names, or it will break:
     * `scroller` - the ScrollerBar container
     * `scroll` - the scroll area
     * `handle` - the scroll handle

--- a/Docs/ScrollerBar.md
+++ b/Docs/ScrollerBar.md
@@ -16,8 +16,8 @@ ScrollerBar Method: constructor {#ScrollerBar:constructor}
 ### Options:
 1. `step` (int) how many pixels to move for each scroll step (default is `30`).
 2. `mode` (string) can be either `vertical` or `horizontal` (default is `vertical`).
-3. `margins` (int) how many margins to add to the end of the scroll zone (can help fix some issues). default is `0`.
-4. `alwaysShow` (bool) - if set to true, will show the bar even if there is no scrolling needed. default is `false`.
+3. `margins` (int) how many margins to add to the end of the scroll zone (can help fix some issues) (default is `0`).
+4. `alwaysShow` (bool) - if set to true, will show the bar even if there is no scrolling needed (default is `false`).
 5. `crollerHTML` (string) - the html used to create the ScrollerBar. If you wish to customize it, make sure you keep the default class names, or it will break:
     * `scroller` - the ScrollerBar container
     * `scroll` - the scroll area

--- a/Source/ScrollerBar.css
+++ b/Source/ScrollerBar.css
@@ -24,7 +24,7 @@
         .decrease{
             display:block;
             position:absolute;
-            width:0px;
+            width:0;
             height:0;
             cursor:pointer;
         }

--- a/Source/ScrollerBar.css
+++ b/Source/ScrollerBar.css
@@ -17,6 +17,7 @@
             cursor: pointer; 
             background:#ccc; 
             -moz-border-radius:4px;
+            -webkit-border-radius: 4px;
             border-radius:4px;
          }
     

--- a/Source/ScrollerBar.css
+++ b/Source/ScrollerBar.css
@@ -4,7 +4,6 @@
         }
         
         .scroll {
-            background:#fff; 
             position:absolute; 
             -moz-border-radius:4px;
             -webkit-border-radius:4px;

--- a/Source/ScrollerBar.js
+++ b/Source/ScrollerBar.js
@@ -50,6 +50,7 @@ var params = {
             +'<span class="increase"></span>'
         , mode : 'vertical'
         , margins : 0
+        , margin : 0 // correct spelling for margin
         , wrapped : null
         , alwaysShow : false
     }
@@ -107,7 +108,12 @@ var params = {
         
         this.scroller.handle.setStyle(this.property,handleSize);
 
-        if (this.areaSize >= this.scrollSize+this.options.margins 
+        // spelling correction for "margins" option:
+        if (this.options.margins) {
+            this.options.margin = this.options.margins;
+        }
+
+        if (this.areaSize >= this.scrollSize+this.options.margin
             && false == this.options.alwaysShow
         ) {
             this.hide();
@@ -120,7 +126,7 @@ var params = {
                 {
                     mode : this.options.mode,
                     range : [
-                        0, this.scrollSize - this.areaSize / 2 + this.options.margins
+                        0, this.scrollSize - this.areaSize / 2 + this.options.margin
                     ]
                 }
             );

--- a/Source/ScrollerBar.js
+++ b/Source/ScrollerBar.js
@@ -113,7 +113,16 @@ var params = {
             this.hide();
         }
 
-        this.slider = new Slider(this.scroller.scroll,this.scroller.handle,{mode:this.options.mode, range : [0,this.scrollSize-this.areaSize/2+this.options.margins]});
+        this.slider = new Slider(
+            this.scroller.scroll,
+            this.scroller.handle,
+            {
+                mode : this.options.mode,
+                range : [
+                    0, this.scrollSize - this.areaSize / 2 + this.options.margins
+                ]
+            }
+        );
         
         this.generated = true;
     }

--- a/Source/ScrollerBar.js
+++ b/Source/ScrollerBar.js
@@ -107,7 +107,11 @@ var params = {
         
         this.scroller.handle.setStyle(this.property,handleSize);
 
-        if (this.areaSize >= this.scrollSize+this.options.margins && false == this.options.alwaysShow) this.hide();
+        if (this.areaSize >= this.scrollSize+this.options.margins 
+            && false == this.options.alwaysShow
+        ) {
+            this.hide();
+        }
 
         this.slider = new Slider(this.scroller.scroll,this.scroller.handle,{mode:this.options.mode, range : [0,this.scrollSize-this.areaSize/2+this.options.margins]});
         

--- a/Source/ScrollerBar.js
+++ b/Source/ScrollerBar.js
@@ -133,38 +133,41 @@ var params = {
         
         if (this.attached) return;
         
-        this.events = {
-            scrollUp :function scrollUp(){
-                $this.slider.set($this.position - $this.options.step);
-            }
-            , scrollDown : function scrollDown(){
-                $this.slider.set($this.position + $this.options.step);
-            }
-            , manageWheel : function manageWheel(e){
-                e.preventDefault();
-                if (e.wheel >0){
-                    $this.events.scrollUp();
-                }else{
-                    $this.events.scrollDown();
-                }    
-            }
-        };
-        
-        this.element.addEvent('mousewheel',this.events.manageWheel);
-                
-        this.scroller.inc.addEvent('click',this.events.scrollUp);
-        this.scroller.dec.addEvent('click',this.events.scrollDown);
-        
-        this.slider.addEvent('change' , function(pos){
-            if (pos < $this.position) $this.decrease($this.position - pos);
-            else $this.increase(pos - $this.position);
-        });
-        
+        if (this.slider) {
+            this.events = {
+                scrollUp :function scrollUp(){
+                    $this.slider.set($this.position - $this.options.step);
+                }
+                , scrollDown : function scrollDown(){
+                    $this.slider.set($this.position + $this.options.step);
+                }
+                , manageWheel : function manageWheel(e){
+                    e.preventDefault();
+                    if (e.wheel >0){
+                        $this.events.scrollUp();
+                    }else{
+                        $this.events.scrollDown();
+                    }    
+                }
+            };
+            
+            this.element.addEvent('mousewheel',this.events.manageWheel);
+                    
+            this.scroller.inc.addEvent('click',this.events.scrollUp);
+            this.scroller.dec.addEvent('click',this.events.scrollDown);
+            
+            this.slider.addEvent('change' , function(pos){
+                if (pos < $this.position) $this.decrease($this.position - pos);
+                else $this.increase(pos - $this.position);
+            });
+        }
+        // even if nothing is attached (i.e., this.slider = null), we don't
+        // want to run through attach() again
         this.attached = true;
     }
     , detach : function detach(){
         this.element.removeEvent('mousewheel',this.events.manageWheel);
-        this.slider.detach();
+        if (this.slider) this.slider.detach();
         this.scroller.each(function(el){el.destroy();});
         this.generated = false;
         this.attached = false;

--- a/Source/ScrollerBar.js
+++ b/Source/ScrollerBar.js
@@ -111,20 +111,22 @@ var params = {
             && false == this.options.alwaysShow
         ) {
             this.hide();
+            this.slider = null;
+            this.generated = false;
+        } else {
+            this.slider = new Slider(
+                this.scroller.scroll,
+                this.scroller.handle,
+                {
+                    mode : this.options.mode,
+                    range : [
+                        0, this.scrollSize - this.areaSize / 2 + this.options.margins
+                    ]
+                }
+            );
+            this.generated = true;
         }
-
-        this.slider = new Slider(
-            this.scroller.scroll,
-            this.scroller.handle,
-            {
-                mode : this.options.mode,
-                range : [
-                    0, this.scrollSize - this.areaSize / 2 + this.options.margins
-                ]
-            }
-        );
         
-        this.generated = true;
     }
     , attach : function attach(){
         var $this = this;

--- a/Source/ScrollerBar.js
+++ b/Source/ScrollerBar.js
@@ -133,8 +133,6 @@ var params = {
         
         if (this.attached) return;
         
-        if (!this.generated) this.generate();
-        
         this.events = {
             scrollUp :function scrollUp(){
                 $this.slider.set($this.position - $this.options.step);


### PR DESCRIPTION
For the most part, the work I did on this fixed some spelling/grammar in the Docs, as well as did some formatting/consistency work on the markdown for the Docs.

I also deprecated the "margins" option in favor of "margin", which is the correct spelling in this case.

And finally, I added some conditional statements around the Slider call, and anything in the code referring to this.slider(), as when the ScrollerBar is not rendered due to the ratio being equal to 1 or greater, the sliding functionality was still in place, which didn't make too much sense.
